### PR TITLE
Suppression du "bgc-dark-slate-blue" dans l'index et le style.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 		<!-- bloc-0 END -->
 
 		<!-- bloc-1-presentation -->
-		<div class="bloc bgc-dark-slate-blue bg-banniere d-bloc bg-t-edge bloc-bg-texture texture-paper b-parallax"
+		<div class="bloc  bg-banniere d-bloc bg-t-edge bloc-bg-texture texture-paper b-parallax"
 			id="bloc-1-hero">
 			<div class="container bloc-lg">
 				<div class="row tight-width-whitespace">
@@ -232,7 +232,7 @@
 		<!-- bloc-4-portfolio END -->
 
 		<!-- bloc-5-cta -->
-		<div class="bloc bgc-dark-slate-blue bg-banniere d-bloc bloc-bg-texture texture-paper" id="bloc-5-cta">
+		<div class="bloc bg-banniere d-bloc bloc-bg-texture texture-paper" id="bloc-5-cta">
 			<div class="container bloc-lg">
 				<div class="row">
 					<h2 class="mg-md text-center ltc-white">

--- a/style.css
+++ b/style.css
@@ -766,10 +766,6 @@ h4 {
     background-color: #FFFFFF;
 }
 
-.bgc-dark-slate-blue {
-    background-color: #B0D0BE;
-}
-
 .bgc-atomic-tangerine {
     background-color: #B0D0BE;
 }


### PR DESCRIPTION
La class bgc-dark-slate-blue  causait un problème d'accessibilité détecté par l'extension wave.