### PR TITLE
Rajout de la class bgc-dark-slate-blue supprimée ultérieurement

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 		<!-- bloc-0 END -->
 
 		<!-- bloc-1-presentation -->
-		<div class="bloc  bg-banniere d-bloc bg-t-edge bloc-bg-texture texture-paper b-parallax"
+		<div class="bloc bgc-dark-slate-blue bg-banniere d-bloc bg-t-edge bloc-bg-texture texture-paper b-parallax"
 			id="bloc-1-hero">
 			<div class="container bloc-lg">
 				<div class="row tight-width-whitespace">
@@ -232,7 +232,7 @@
 		<!-- bloc-4-portfolio END -->
 
 		<!-- bloc-5-cta -->
-		<div class="bloc bg-banniere d-bloc bloc-bg-texture texture-paper" id="bloc-5-cta">
+		<div class="bloc bgc-dark-slate-blue bg-banniere d-bloc bloc-bg-texture texture-paper" id="bloc-5-cta">
 			<div class="container bloc-lg">
 				<div class="row">
 					<h2 class="mg-md text-center ltc-white">

--- a/style.css
+++ b/style.css
@@ -766,6 +766,10 @@ h4 {
     background-color: #FFFFFF;
 }
 
+.bgc-dark-slate-blue {
+    background-color: darkslateblue;
+}
+
 .bgc-atomic-tangerine {
     background-color: #B0D0BE;
 }


### PR DESCRIPTION
La suppression de cette class a rendu le fond blanc. Le texte étant blanc, ce n'était pas acceptable niveau accessibilité (même si le fond est rendu invisible). Du coup, class rajoutée et couleur remise comme c'était de base : darkslateblue.